### PR TITLE
SqlCommandPublisher의 Envelope 관련 복원 오류 수정

### DIFF
--- a/source/Khala.Processes.SqlCore/Processes/Sql/SqlCommandPublisher.cs
+++ b/source/Khala.Processes.SqlCore/Processes/Sql/SqlCommandPublisher.cs
@@ -88,7 +88,9 @@
             new Envelope(
                 command.MessageId,
                 _serializer.Deserialize(command.CommandJson),
-                correlationId: command.CorrelationId);
+                operationId: command.OperationId,
+                correlationId: command.CorrelationId,
+                contributor: command.Contributor);
 
         private static async Task RemoveCommands(
             ProcessManagerDbContext dbContext,
@@ -157,7 +159,9 @@
                 new Envelope(
                     scheduledCommand.MessageId,
                     _serializer.Deserialize(scheduledCommand.CommandJson),
-                    correlationId: scheduledCommand.CorrelationId),
+                    operationId: scheduledCommand.OperationId,
+                    correlationId: scheduledCommand.CorrelationId,
+                    contributor: scheduledCommand.Contributor),
                 scheduledCommand.ScheduledTimeUtc);
 
         private static async Task RemoveScheduledCommands(

--- a/source/Khala.Processes.Tests.Core/Processes/Sql/SqlCommandPublisher_specs.cs
+++ b/source/Khala.Processes.Tests.Core/Processes/Sql/SqlCommandPublisher_specs.cs
@@ -101,7 +101,12 @@
                     new FakeCommand { Int32Value = random.Next(), StringValue = fixture.Create<string>() },
                     new FakeCommand { Int32Value = random.Next(), StringValue = fixture.Create<string>() },
                 }
-                select new Envelope(Guid.NewGuid(), command, null, Guid.NewGuid(), null));
+                select new Envelope(
+                    Guid.NewGuid(),
+                    command,
+                    operationId: Guid.NewGuid().ToString(),
+                    correlationId: Guid.NewGuid(),
+                    contributor: Guid.NewGuid().ToString()));
 
             using (var db = new ProcessManagerDbContext(_dbContextOptions))
             {
@@ -329,7 +334,12 @@
                     new FakeCommand { Int32Value = random.Next(), StringValue = fixture.Create<string>() },
                     new FakeCommand { Int32Value = random.Next(), StringValue = fixture.Create<string>() },
                 }
-                let envelope = new Envelope(Guid.NewGuid(), command, null, Guid.NewGuid(), null)
+                let envelope = new Envelope(
+                    Guid.NewGuid(),
+                    command,
+                    operationId: Guid.NewGuid().ToString(),
+                    correlationId: Guid.NewGuid(),
+                    contributor: Guid.NewGuid().ToString())
                 select new ScheduledEnvelope(envelope, DateTime.UtcNow.AddTicks(random.Next())));
 
             using (var db = new ProcessManagerDbContext(_dbContextOptions))


### PR DESCRIPTION
SqlCommandPublisher가 OperationId와 Contributor를 복원하지 않던 문제점을
해결한다.

this resolves #13